### PR TITLE
name requires the full file name of the extension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 func main() {
     ctx, cancel := context.WithCancel(context.Background())
     defer cancel()
-    client, _ := extensions.NewClient("my-extension")
+    client, _ := extensions.NewClient()
     client.CallbackInvoke = func (ctx context.Context, event *extensions.InvokeEvent) error {
         log.Printf("invoke event: %v", event)
         // do something on invoke event
@@ -60,7 +60,7 @@ func main() {
        // run http server listening on 9999 for receiving telemetry data
     }()
 
-    client, _ := extensions.NewClient("my-telemetry")
+    client, _ := extensions.NewClient()
     client.CallbackShutdown = func (ctx context.Context, event *extensions.ShutdownEvent) error {
         log.Printf("shutdown event: %v", event)
         // do something

--- a/extensions.go
+++ b/extensions.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 )
 
 type EventType string
@@ -51,7 +52,8 @@ type Client struct {
 }
 
 // NewClient creates a new client for Lambda Extensions API
-func NewClient(name string) (*Client, error) {
+func NewClient() (*Client, error) {
+	name := filepath.Base(os.Args[0])
 	host := os.Getenv("AWS_LAMBDA_RUNTIME_API")
 	if host == "" {
 		return nil, fmt.Errorf("AWS_LAMBDA_RUNTIME_API is not set")

--- a/extensions_test.go
+++ b/extensions_test.go
@@ -18,7 +18,7 @@ func TestMockAPI(t *testing.T) {
 	defer sv.Close()
 
 	ctx := context.Background()
-	c, err := extensions.NewClient("test")
+	c, err := extensions.NewClient()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html#runtimes-extensions-api-reg

> API call must include the Lambda-Extension-Name header with **the full file name of the extension**.

